### PR TITLE
feat: add universal biome name formatting

### DIFF
--- a/src/main/java/bl4ckscor3/mod/biomeinfo/BiomeInfoRenderer.java
+++ b/src/main/java/bl4ckscor3/mod/biomeinfo/BiomeInfoRenderer.java
@@ -61,6 +61,17 @@ public class BiomeInfoRenderer {
 		}
 	}
 
+	private static String formatBiomeName(String biomeId) {
+		String[] words = biomeId.split("_");
+		StringBuilder formatted = new StringBuilder();
+
+		for (String word : words) {
+			formatted.append(word.substring(0, 1).toUpperCase()).append(word.substring(1)).append(" ");
+		}
+
+		return formatted.toString().trim();
+	}
+
 	public static void renderBiomeInfo(GuiGraphics guiGraphics, DeltaTracker deltaTracker) {
 		if (complete && Configuration.enabled() && (!Configuration.hideOnDebugScreen() || !Minecraft.getInstance().getDebugOverlay().showDebugScreen())) {
 			Minecraft mc = Minecraft.getInstance();
@@ -91,7 +102,17 @@ public class BiomeInfoRenderer {
 				if (alpha > 0) {
 					biomeHolder.unwrapKey().ifPresent(key -> {
 						float scale = (float) Configuration.scale();
-						Component biomeName = Component.translatable(Util.makeDescriptionId("biome", key.location()));
+
+						String translationKey = Util.makeDescriptionId("biome", key.location());
+						Component biomeName = Component.translatable(translationKey);
+
+						String displayedText = biomeName.getString();
+						if (displayedText.equals(translationKey))
+							String biomeId = key.location().getPath(); // just path part (like "birch_forest")
+							String formattedBiomeName = formatBiomeName(biomeId);
+							biomeName = Component.literal(formattedBiomeName);
+						}
+
 						PositionPreset positionPreset = Configuration.positionPreset();
 						int textOffset = positionPreset.textAlignment().getNegativeOffset(mc.font, biomeName);
 						PoseStack pose = guiGraphics.pose();

--- a/src/main/java/bl4ckscor3/mod/biomeinfo/BiomeInfoRenderer.java
+++ b/src/main/java/bl4ckscor3/mod/biomeinfo/BiomeInfoRenderer.java
@@ -107,7 +107,7 @@ public class BiomeInfoRenderer {
 						Component biomeName = Component.translatable(translationKey);
 
 						String displayedText = biomeName.getString();
-						if (displayedText.equals(translationKey))
+						if (displayedText.equals(translationKey)) {
 							String biomeId = key.location().getPath(); // just path part (like "birch_forest")
 							String formattedBiomeName = formatBiomeName(biomeId);
 							biomeName = Component.literal(formattedBiomeName);


### PR DESCRIPTION
This pull request includes changes to improve the display of biome names in the BiomeInfoRenderer class. For now it only worked with vanilla (issue: https://github.com/bl4ckscor3/BiomeInfo/issues/15).

* Added a new method `formatBiomeName` to format biome names by capitalizing each word
* Modified the `renderBiomeInfo` method to check if the biome name is untranslated and use the `formatBiomeName` method to display a formatted version of the biome